### PR TITLE
Bump solr.version from 3.6.2 to 8.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@ under the License.
     <pax-exam.version>1.2.4</pax-exam.version>
     <pax-tiny-bundle.version>1.3.1</pax-tiny-bundle.version>
 
-    <solr.version>3.6.2</solr.version>
+    <solr.version>8.2.0</solr.version>
     <solr.bundle.version>3.6.2_2</solr.bundle.version>
 
     <protostuff.version>1.0.7</protostuff.version>


### PR DESCRIPTION
Bumps `solr.version` from 3.6.2 to 8.2.0.

Updates `solr-core` from 3.6.2 to 8.2.0

Updates `solr-test-framework` from 3.6.2 to 8.2.0

Signed-off-by: dependabot[bot] <support@github.com>